### PR TITLE
Update Mitschrift_InfStat.tex

### DIFF
--- a/Mitschrift_InfStat.tex
+++ b/Mitschrift_InfStat.tex
@@ -440,7 +440,7 @@ da
 
 
 \begin{align*}
-	\textcolor{orange}{\mathbb{E}\left(\left(X-\iota\bar{X}\right)\left(X-\iota\bar{X}\right)^{\prime}\right)} & =VC(X-\iota X)\\
+	\textcolor{orange}{\mathbb{E}\left(\left(X-\iota\bar{X}\right)\left(X-\iota\bar{X}\right)^{\prime}\right)} & =VC(X-\iota\bar{X})\\
 	& =VC(X-\iota\frac{1}{n}\iota^{\prime}X)\\
 	& =VC\left(\left(I_{n}-\iota\frac{1}{n}\iota^{\prime}\right)X\right)\\
 	& =\left(I_{n}-\iota\frac{1}{n}\iota^{\prime}\right)VC(X)\left(I_{n}-\iota\frac{1}{n}\iota^{\prime}\right)^{\prime}\\
@@ -1072,7 +1072,7 @@ Zu zeigen: $ \E(f(x)g(y)) = \E(f(x))E(g(y)). $
 		X_1 \\ \vdots \\ X_n
 	\end{pmatrix} \sim N(\mu^2. \sigma^2 I_n) $. \\
 	
-	$ X - \bar{X} \iota = \underbrace{\left(I_n - \iota \frac{1}{n} \iota^\prime\right)}_{\coloneqq P} X \ldots $ Orthogonalprojektion von $ X $ auf $ [\iota]^\perp $, ein $ (n-1) $.dimensionaler Teilraum.
+	$ X - \iota\bar{X}  = \underbrace{\left(I_n - \iota \frac{1}{n} \iota^\prime\right)}_{\coloneqq P} X \ldots $ Orthogonalprojektion von $ X $ auf $ [\iota]^\perp $, ein $ (n-1) $.dimensionaler Teilraum.
 	
 	Prüfe Eigenschaften: 
 	\[


### PR DESCRIPTION
Zeile 443 --> das "quer" über X vergessen und 
Zeile 1075. Da bin ich mir nicht 100% sicher abe rich glaube die Reihenfolge von iota und X quer ist vertauscht.  Wegen der Vektorrechnung aber wichtig.
da ich mit latex nicht so bewandert bin, hoffe ich dass ich es richtig ausgebessert habe.
Du siehst ich nutze deine Mitschirft zum lernen :)